### PR TITLE
Implement Raylib shutdown cleanup

### DIFF
--- a/RaylibBackend.cs
+++ b/RaylibBackend.cs
@@ -36,5 +36,6 @@ public class RaylibBackend : IRenderBackend
     }
     public void Shutdown()
     {
+        Raylib.CloseWindow();
     }
 }


### PR DESCRIPTION
## Summary
- close the window when shutting down the Raylib backend

## Testing
- `dotnet build Engine.Rendering.RaylibBackend.csproj -clp:ErrorsOnly` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6840059f5254832785dcfb88edb4dfbe