### PR TITLE
Normalize C# encoding

### DIFF
--- a/Engine.Rendering.RaylibBackend.csproj
+++ b/Engine.Rendering.RaylibBackend.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>

--- a/RaylibBackend.cs
+++ b/RaylibBackend.cs
@@ -1,4 +1,4 @@
-﻿using System.Numerics;
+using System.Numerics;
 using Engine.Rendering.Textures;
 using Raylib_cs;
 

--- a/RaylibCamera.cs
+++ b/RaylibCamera.cs
@@ -1,4 +1,4 @@
-﻿using Engine.Rendering.Cameras;
+using Engine.Rendering.Cameras;
 using Raylib_cs;
 
 namespace Engine.Rendering.RaylibBackend;

--- a/RaylibCameraCreator.cs
+++ b/RaylibCameraCreator.cs
@@ -1,4 +1,4 @@
-﻿using Engine.Rendering.Cameras;
+using Engine.Rendering.Cameras;
 
 namespace Engine.Rendering.RaylibBackend;
 

--- a/RaylibRenderingBundle.cs
+++ b/RaylibRenderingBundle.cs
@@ -1,4 +1,4 @@
-﻿using Engine.Core;
+using Engine.Core;
 using Engine.Core.Di;
 using Engine.Rendering.Cameras;
 using Engine.Rendering.Materials;

--- a/RaylibTexture.cs
+++ b/RaylibTexture.cs
@@ -1,4 +1,4 @@
-﻿using Engine.Rendering.Textures;
+using Engine.Rendering.Textures;
 using Raylib_cs;
 
 namespace Engine.Rendering.RaylibBackend;

--- a/RaylibTextureLoader.cs
+++ b/RaylibTextureLoader.cs
@@ -1,4 +1,4 @@
-﻿using Engine.Core.Serialization;
+using Engine.Core.Serialization;
 using Engine.Rendering.Textures;
 using Raylib_cs;
 

--- a/Shaders/RaylibShaderLoader.cs
+++ b/Shaders/RaylibShaderLoader.cs
@@ -1,4 +1,4 @@
-﻿using Engine.Rendering.Shaders;
+using Engine.Rendering.Shaders;
 using Raylib_cs;
 
 namespace Engine.Rendering.RaylibBackend.Shaders;

--- a/Shaders/RaylibShaderProgram.cs
+++ b/Shaders/RaylibShaderProgram.cs
@@ -1,4 +1,4 @@
-﻿using Engine.Rendering.Shaders;
+using Engine.Rendering.Shaders;
 using Raylib_cs;
 
 namespace Engine.Rendering.RaylibBackend.Shaders;


### PR DESCRIPTION
## Summary
- encode all `.cs` and `.csproj` files as UTF-8 without BOM
- ensure exactly one trailing newline

## Testing
- `dotnet build Engine.Rendering.RaylibBackend.csproj -v q` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68400577be24832781e48fe0f23b3595